### PR TITLE
Fix TS compilation error

### DIFF
--- a/types/VueRoughNotation.d.ts
+++ b/types/VueRoughNotation.d.ts
@@ -9,6 +9,6 @@ export interface VueRoughNotationOptions {
   strokeWidth?: number;
   padding?: number;
   iterations?: number;
-};
+}
 
-export interface VueRoughNotationPluginObject extends PluginObject<VueRoughNotationOptions> {};
+export interface VueRoughNotationPluginObject extends PluginObject<VueRoughNotationOptions> {}


### PR DESCRIPTION
TS error: Statements are not allowed in ambient contexts:
```
ERROR in node_modules/vue-rough-notation/types/VueRoughNotation.d.ts(12,2):
12:2 Statements are not allowed in ambient contexts.
    10 |     padding?: number;
    11 |     iterations?: number;
  > 12 | };
       |  ^
    13 | 
    14 | export interface VueRoughNotationPluginObject extends PluginObject<VueRoughNotationOptions> {
    15 | };
ℹ Version: typescript 3.8.3
```

vue-rough-notation@0.1.8